### PR TITLE
Solved Test Flakiness in createOrder test 

### DIFF
--- a/src/test/java/giis/eshopcontainers/e2e/functional/common/BaseLoggedClass.java
+++ b/src/test/java/giis/eshopcontainers/e2e/functional/common/BaseLoggedClass.java
@@ -47,13 +47,13 @@ public class BaseLoggedClass {
         properties = new Properties();
         // load a properties file for reading
         properties.load(Files.newInputStream(Paths.get("src/test/resources/test.properties")));
-        String envUrl = System.getProperty("SUT_URL");
+        String envUrl = System.getProperty("SUT_URL") != null ? System.getProperty("SUT_URL") : System.getenv("SUT_URL");
         if (envUrl == null) {
             // Outside CI
             sutUrl = properties.getProperty("LOCALHOST_URL");
             log.debug("Configuring the local browser to connect to a local System Under Test (SUT) at: " + sutUrl);
         } else {
-            sutUrl = envUrl + ":" + System.getProperty("SUT_PORT") + "/";
+            sutUrl = envUrl + ":" + (System.getProperty("SUT_PORT") != null ? System.getProperty("SUT_PORT") : System.getenv("SUT_PORT")) + "/";
             log.debug("Configuring the browser to connect to the remote System Under Test (SUT) at the following URL: " + sutUrl);
         }
         setupBrowser();

--- a/src/test/java/giis/eshopcontainers/e2e/functional/tests/OrderTests.java
+++ b/src/test/java/giis/eshopcontainers/e2e/functional/tests/OrderTests.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
@@ -127,6 +128,28 @@ class OrderTests extends BaseLoggedClass {
         checkOrderAmountAndNumItems("$ 36.00", 4);
         WebElement buttonPlaceOrder = driver.findElement(By.name("action"));
         Click.element(driver, waiter, buttonPlaceOrder);
+        Assertions.assertEquals(checkOrderPlaced(), true, "The order was not placed until 5 seconds");
+
+    }
+
+    /**
+     * Method to check if order is correctly placed by verifying that the basket is clear
+     * Returns true if the basket is clear (number of elements is 0), otherwise returns false
+     **/
+    public boolean checkOrderPlaced() throws ElementNotFoundException {
+        int totalAttempts = 5; // Total attempts allowed to check if the order is placed
+        while (totalAttempts > 0) {
+            try {
+                // Wait until the basket status badge indicates 0 items
+                waiter.waitUntil(ExpectedConditions.textToBe(By.className("esh-basketstatus-badge"), "0"), "The Basket value is not 0");
+                return true; // Order is placed successfully
+            } catch (TimeoutException e) {
+                // If timeout occurs, navigate back to the main menu and decrement the attempts
+                toMainMenu(driver, waiter);
+                totalAttempts--; // Decrement total attempts
+            }
+        }
+        return false; // Order could not be placed within the specified attempts
     }
 
     /**

--- a/src/test/java/giis/eshopcontainers/e2e/functional/tests/OrderTests.java
+++ b/src/test/java/giis/eshopcontainers/e2e/functional/tests/OrderTests.java
@@ -133,9 +133,12 @@ class OrderTests extends BaseLoggedClass {
     }
 
     /**
-     * Method to check if order is correctly placed by verifying that the basket is clear
-     * Returns true if the basket is clear (number of elements is 0), otherwise returns false
+     * Method to verify if an order is correctly placed by ensuring that the basket is empty.
+     * This verification should also be extended to the consistency of the database, not solely relying on the final UI state.
+     * While detailed functional tests are not conducted, this UI check its enough for now.
+     * @return true if the basket is empty (no elements), otherwise returns false.
      **/
+
     public boolean checkOrderPlaced() throws ElementNotFoundException {
         int totalAttempts = 5; // Total attempts allowed to check if the order is placed
         while (totalAttempts > 0) {


### PR DESCRIPTION
Due to the variability in the system's processing speed, the createOrder test was failing because the order had not been completed (i.e., stored in the database) by the time the test verified it. This pull request incorporates a method that waits until the order is fulfilled before successfully verifying its state.