### PR TITLE
Solving test Flakiness in OrderTests due to DB Migration timeouts closes #71

### DIFF
--- a/sut/src/Services/Ordering/Ordering.API/Program.cs
+++ b/sut/src/Services/Ordering/Ordering.API/Program.cs
@@ -62,7 +62,9 @@ using (var scope = app.Services.CreateScope())
     var env = app.Services.GetService<IWebHostEnvironment>();
     var settings = app.Services.GetService<IOptions<OrderingSettings>>();
     var logger = app.Services.GetService<ILogger<OrderingContextSeed>>();
-    await context.Database.MigrateAsync();
+    //RETORCH: Increasing the timeout to avoid flakys when its parallelized the system. Added ConfigureAwait(false)
+    context.Database.SetCommandTimeout(300);
+    await context.Database.MigrateAsync().ConfigureAwait(false);
 
     await new OrderingContextSeed().SeedAsync(context, env, settings, logger);
     var integEventContext = scope.ServiceProvider.GetRequiredService<IntegrationEventLogContext>();

--- a/sut/src/Services/Ordering/Ordering.API/Program.cs
+++ b/sut/src/Services/Ordering/Ordering.API/Program.cs
@@ -63,7 +63,7 @@ using (var scope = app.Services.CreateScope())
     var settings = app.Services.GetService<IOptions<OrderingSettings>>();
     var logger = app.Services.GetService<ILogger<OrderingContextSeed>>();
     //RETORCH: Increasing the timeout to avoid flakys when its parallelized the system. Added ConfigureAwait(false)
-    context.Database.SetCommandTimeout(300);
+    context.Database.SetCommandTimeout(150);
     await context.Database.MigrateAsync().ConfigureAwait(false);
 
     await new OrderingContextSeed().SeedAsync(context, env, settings, logger);


### PR DESCRIPTION
Increased the timeout of the DB migration to 150 seconds. This solves test flakiness in TJobE due to the not-ready state of the Orders API.
