### PR TITLE
SQLTest healthcheck update to align with msqlserver:CU28-2019

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,9 @@
 			</dependency>
 		</dependencies>
 	<build>
+		<!-- To avoid problems with concurrency we change the directories of the reports and outputs -->
+		<testOutputDirectory>${basedir}/target/test-classes/${dirtarget}</testOutputDirectory>
+		<outputDirectory>${basedir}/target/classes/${dirtarget}</outputDirectory>
 		<pluginManagement>
 			<plugins>
 				<plugin>

--- a/sut/src/Services/Services.Common/Services.Common.csproj
+++ b/sut/src/Services/Services.Common/Services.Common.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
     <PackageReference Include="Polly" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
-    <PackageReference Include="System.Data.SqlClient" />
+    <PackageReference Include="System.Data.SqlClient" Version="5.2.1"  />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />

--- a/sut/src/Services/Services.Common/Services.Common.csproj
+++ b/sut/src/Services/Services.Common/Services.Common.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
     <PackageReference Include="Polly" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
-    <PackageReference Include="System.Data.SqlClient" Version="5.2.1"  />
+    <PackageReference Include="System.Data.SqlClient"  />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />

--- a/sut/src/docker-compose.yml
+++ b/sut/src/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       interval: 10s
       timeout: 3s
       retries: 10
-      start_period: 10s
+      start_period: 20s
 
   nosqldata:
     container_name: nosqldata_${tjobname}
@@ -151,8 +151,9 @@ services:
     healthcheck:
       test: "curl -f http://localhost/hc || exit 1"
       interval: 30s
-      timeout: 30s
-      retries: 10
+      timeout: 3s
+      retries: 15
+      start_period: 25s
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
       - Kestrel__Endpoints__HTTP__Url=http://0.0.0.0:80

--- a/sut/src/docker-compose.yml
+++ b/sut/src/docker-compose.yml
@@ -187,6 +187,8 @@ services:
       context: .
       dockerfile: Services/Ordering/Ordering.BackgroundTasks/Dockerfile
     depends_on:
+      ordering-api:
+        condition: service_healthy
       sqldata:
         condition: service_healthy
       rabbitmq:

--- a/sut/src/docker-compose.yml
+++ b/sut/src/docker-compose.yml
@@ -9,7 +9,7 @@ services:
 
   sqldata:
     container_name: sqldata_${tjobname}
-    image: mcr.microsoft.com/mssql/server:2019-latest
+    image: mcr.microsoft.com/mssql/server:2019-CU28-ubuntu-20.04
     environment:
       - SA_PASSWORD=Pass@word
       - ACCEPT_EULA=Y
@@ -18,9 +18,11 @@ services:
     networks:
       - jenkins_network
     healthcheck:
-      test: "/opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P \"Pass@word\" -Q \"SELECT name FROM master.sys.databases\""
-      timeout: 20s
+      test: "/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U SA -P \"Pass@word\" -Q \"SELECT name FROM master.sys.databases\""
+      interval: 10s
+      timeout: 3s
       retries: 10
+      start_period: 10s
 
   nosqldata:
     container_name: nosqldata_${tjobname}


### PR DESCRIPTION
This PR closes #104.
A recently cumulative update of msqlserver (sqldata container) broke up all the Dependabot updates in our CI system. We have changed the directory of the sqlcmd binary. Once updated, I've realized of some concurrency problems between our test cases, so I applied the same strategy than [Fullteaching](https//github.com/giis-uniovi/retorch-st-fullteaching/) test suite.
The changes are:
 - We have changed the location of sqlcmd binary to the newer ones
 - We have changed the test output directories (one for each TJob)
 - We have changed the background tasks dependencies to dont start and not saturate with requests the msql container
 - Solved some flakiness due to timeouts of order-state changes