### PR TITLE
Adding `directory` to the build to avoid concurrency problems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,9 +88,8 @@
 			</dependency>
 		</dependencies>
 	<build>
-		<!-- To avoid problems with concurrency we change the directories of the reports and outputs -->
-		<testOutputDirectory>${basedir}/target/test-classes/${dirtarget}</testOutputDirectory>
-		<outputDirectory>${basedir}/target/classes/${dirtarget}</outputDirectory>
+		<!-- To avoid problems with concurrency we change the directories of the reports, outputs and build -->
+		<directory>${project.basedir}/target/${tjob_name}</directory>
 		<pluginManagement>
 			<plugins>
 				<plugin>

--- a/retorchfiles/scripts/coilifecycles/coi-setup.sh
+++ b/retorchfiles/scripts/coilifecycles/coi-setup.sh
@@ -21,14 +21,14 @@ OUTPUTDIRCOI="$WORKSPACE/retorchcostestimationdata/exec$BUILD_NUMBER/COI.data"
 COISETUPSTART=$(date +%s%3N)
 
 # Prompt some system information
-docker_version=$(docker --version | awk '{print $3}')
+docker_version=$(docker version)
 docker_compose_version=$(docker compose version | awk '{print $4}')
 curl_version=$(curl --version | head -n 1 | awk '{print $2}')
 kernel_version=$(uname -r)
 os_version=$(cat /etc/os-release | grep PRETTY_NAME | cut -d '"' -f 2)
 
-"$SCRIPTS_FOLDER/printLog.sh" "INFO" "COI-set-up" "Os version : $os_version, Kernel version: $kernel_version, Docker version: $docker_version, Docker-compose version: $docker_compose_version, curl-version: $curl_version"
-
+"$SCRIPTS_FOLDER/printLog.sh" "INFO" "COI-set-up" "Os version : $os_version, Kernel version: $kernel_version,  Docker-compose version: $docker_compose_version, curl-version: $curl_version"
+"$SCRIPTS_FOLDER/printLog.sh" "INFO" "COI-set-up" "Full Docker versions:\n $docker_version"
 # Remove older videos (older than 15 days)
 remove_old_files "$SEL_VIDEO_DIR" 15
 

--- a/retorchfiles/scripts/tjoblifecycles/tjob-testexecution.sh
+++ b/retorchfiles/scripts/tjoblifecycles/tjob-testexecution.sh
@@ -36,7 +36,7 @@ EXECUTE_TIMESTAMP_SCRIPT "$STAGE" "$TJOB_NAME"
 
 LOCALHOST="$DOCKER_HOST_IP:$PORT"
 # Run Maven test
-mvn test -Ddirtarget="$TJOBNAME" -Dtest="$TEST_NAME" -Dtjob_name="$TJOB_NAME" -DSUT_URL="$SUT_URL" -DSUT_PORT="$PORT"
+mvn test -Dtest="$TEST_NAME" -Dtjob_name="$TJOB_NAME" -DSUT_URL="$SUT_URL" -DSUT_PORT="$PORT"
 
 # Store Test result
 MVN_EXIT_CODE=$?


### PR DESCRIPTION
This PR closes #94 
As suggested by [Javier](https://github.com/giis-uniovi/retorch-st-eShopContainers/issues/94#issuecomment-2302554727), I've simplified the target directory and the execution command to store each TJob build data separately. This PR contains:
- Pom modifications to store  build data
- TJob execution script simplification (Reduction of duplicated parameters)
- Logs docker relevant information like containerd, dockerce dockercli versions