### PR TITLE
Fixing SUT local deployment

### DIFF
--- a/.retorch/envfiles/local.env
+++ b/.retorch/envfiles/local.env
@@ -1,0 +1,7 @@
+# Environment file for local deployment (no Jenkins/Selenium Grid required)
+APP_URL=http://localhost:5100
+MEDIASERVER=eexit/mirror-http-server
+TESTS_BASE_PATH=./
+TJOB_NAME=local
+ESHOP_EXTERNAL_DNS_NAME_OR_IP=localhost
+ESHOP_STORAGE_CATALOG_URL=http://localhost:5121/c/api/v1/catalog/items/[0]/pic/

--- a/README.md
+++ b/README.md
@@ -9,12 +9,38 @@ architecture
 using Docker containers. See more details in the [forked version](https://github.com/erjain/eShopOnContainers)
 or [official repository](https://github.com/dotnet-architecture/eShopOnContainers)
 
-## Deployment instructions
+## SUT Deployment
 
-The net core containers would get in trouble due to the number of threads and inotify instances of most of the common
-Linux SO.
-To avoid this problem, it's highly recommended to increase the number of users and instances, e.g. modifying the
-`/etc/sysctl.conf` including:
+### Local deployment
+
+The SUT provided in the `📁 /sut` directory is prepared to be deployed using Docker (`>~v26.0.0`) and docker-compose(
+`v2.26.1>~`). To deploy the SUT we dispose of two scripts in the root of the repository: `📜 redeploy-local.ps1` for
+Windows users and `📜 redeploy-local.sh` for Linux users.
+
+These scripts made the necessary configurations and calls the docker compose command with the environment files and
+variables to succeed in the deployment. The script can be configured to rebuild (or not) the Docker images, in order to 
+do that specify the argument `-NoBuild`:
+
+```bash
+.\redeploy-local.ps1 -NoBuild
+```
+
+To tear-down the SUT, the following command is required (and also prompt in the terminal):
+
+```bash
+docker compose -f sut\src\docker-compose.yml `
+    -f sut\src\docker-compose.local-override.yml `
+    --env-file .retorch\envfiles\local.env `
+    -p local down --volumes
+```
+
+### Jenkins CI deployment
+
+The repository contains a `🚀Jenkinsfile` and the necessary scripts in the  `📁 /.retorch` folder to execute the test suite in
+CI. In addition, to the requirements of the [RETORCH tool](https://github.com/giis-uniovi/retorch) for this concrete demonstrator the user can get in trouble
+due to the number of instances required.
+To avoid this problem,  Linux users are highly  encouraged to increase the number of users and instances in their system,
+e.g. modifying the `/etc/sysctl.conf` including:
 
 ```bash
 fs.inotify.max_user_instances=2048

--- a/redeploy-local.ps1
+++ b/redeploy-local.ps1
@@ -1,0 +1,111 @@
+# Tear down any existing local SUT deployment and redeploy eShopContainers.
+# Run from the project root directory.
+#
+# Usage:
+#   .\redeploy-local.ps1             # full build + deploy
+#   .\redeploy-local.ps1 -NoBuild    # skip image build, just redeploy
+
+param(
+    [switch]$NoBuild
+)
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDir   = Split-Path -Parent $MyInvocation.MyCommand.Path
+$SutSrc      = Join-Path $ScriptDir "sut\src"
+$EnvFile     = Join-Path $ScriptDir ".retorch\envfiles\local.env"
+$ComposeFile = Join-Path $SutSrc "docker-compose.yml"
+$OverrideFile= Join-Path $SutSrc "docker-compose.local-override.yml"
+$ProjectName = "local"
+
+# On Windows with Docker Desktop, host.docker.internal is automatically available
+# in both containers and the Windows hosts file. No detection needed.
+$env:HOST_IP = "host.docker.internal"
+
+function Invoke-Compose {
+    param([string[]]$CommandArgs)
+    $baseArgs = @(
+        "compose",
+        "-f", $ComposeFile,
+        "-f", $OverrideFile,
+        "--env-file", $EnvFile,
+        "-p", $ProjectName
+    )
+    & docker @baseArgs @CommandArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "docker compose failed with exit code $LASTEXITCODE"
+    }
+}
+
+Write-Host "=== [1/4] Tearing down existing SUT deployment ===" -ForegroundColor Cyan
+try {
+    Invoke-Compose @("down", "--volumes", "--remove-orphans")
+} catch {
+    Write-Host "  (no existing deployment or teardown warning - continuing)" -ForegroundColor Yellow
+}
+
+if (-not $NoBuild) {
+    Write-Host "=== [2/4] Building Envoy gateway images (require TAG substitution) ===" -ForegroundColor Cyan
+    Invoke-Compose @("build", "webshoppingapigw", "mobileshoppingapigw")
+
+    Write-Host "=== [3/4] Building remaining SUT images ===" -ForegroundColor Cyan
+    Invoke-Compose @("build")
+} else {
+    Write-Host "=== [2/4] Skipping full build (-NoBuild flag set) ===" -ForegroundColor Yellow
+    Write-Host "=== [3/4] Building Envoy gateway images (always rebuilt for correct TAG) ===" -ForegroundColor Cyan
+    Invoke-Compose @("build", "webshoppingapigw", "mobileshoppingapigw")
+}
+
+Write-Host "=== [4/4] Starting SUT containers ===" -ForegroundColor Cyan
+Invoke-Compose @("up", "-d")
+
+Write-Host ""
+Write-Host "Waiting for WebMVC to be ready (up to 200 seconds)..." -ForegroundColor Cyan
+$Counter   = 0
+$WaitLimit = 40
+$Ready     = $false
+
+while ($Counter -lt $WaitLimit) {
+    try {
+        $response = Invoke-WebRequest -Uri "http://localhost:5100" `
+            -UseBasicParsing -TimeoutSec 5 -ErrorAction SilentlyContinue
+        if ($response.Content -match "esh-catalog-item") {
+            $Ready = $true
+            break
+        }
+    } catch {
+        # Not ready yet
+    }
+    $Counter++
+    Write-Host ("  attempt {0}/{1}" -f $Counter, $WaitLimit) -NoNewline
+    Write-Host "`r" -NoNewline
+    Start-Sleep -Seconds 5
+}
+
+Write-Host ""
+
+if (-not $Ready) {
+    Write-Host "ERROR: SUT did not become ready in time. Showing last container logs:" -ForegroundColor Red
+    try { Invoke-Compose @("logs", "--tail", "30") } catch {}
+    exit 1
+}
+
+Write-Host "============================================" -ForegroundColor Green
+Write-Host " SUT is ready!" -ForegroundColor Green
+Write-Host "============================================" -ForegroundColor Green
+Write-Host "  WebMVC      http://localhost:5100"
+Write-Host "  WebSPA      http://localhost:5104"
+Write-Host "  WebStatus   http://localhost:5107"
+Write-Host "  Identity    http://localhost:5105"
+Write-Host "  Seq (logs)  http://localhost:5340"
+Write-Host "  RabbitMQ    http://localhost:15672  (guest/guest)"
+Write-Host "  SQL Server  localhost:5433         (sa/Pass@word)"
+Write-Host ""
+Write-Host "To tear down:"
+Write-Host "  docker compose -f sut\src\docker-compose.yml ``"
+Write-Host "    -f sut\src\docker-compose.local-override.yml ``"
+Write-Host "    --env-file .retorch\envfiles\local.env ``"
+Write-Host "    -p local down --volumes"
+
+Write-Host "Process complete."
+Read-Host -Prompt "Press Enter to exit"

--- a/redeploy-local.sh
+++ b/redeploy-local.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Tear down any existing local SUT deployment and redeploy eShopContainers.
+# Run from the project root directory.
+#
+# Usage:
+#   ./redeploy-local.sh           # full build + deploy
+#   ./redeploy-local.sh --no-build  # skip image build, just redeploy
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUT_SRC="$SCRIPT_DIR/sut/src"
+ENV_FILE="$SCRIPT_DIR/.retorch/envfiles/local.env"
+COMPOSE_FILE="$SUT_SRC/docker-compose.yml"
+OVERRIDE_FILE="$SUT_SRC/docker-compose.local-override.yml"
+PROJECT_NAME="local"
+SKIP_BUILD=false
+
+for arg in "$@"; do
+  [ "$arg" = "--no-build" ] && SKIP_BUILD=true
+done
+
+# Compose command prefix shared by all steps
+COMPOSE="docker compose \
+  -f $COMPOSE_FILE \
+  -f $OVERRIDE_FILE \
+  --env-file $ENV_FILE \
+  -p $PROJECT_NAME"
+
+echo "=== [1/4] Tearing down existing SUT deployment ==="
+$COMPOSE down --volumes --remove-orphans 2>/dev/null || true
+
+if [ "$SKIP_BUILD" = false ]; then
+  echo "=== [2/4] Building Envoy gateway images (require TAG substitution) ==="
+  $COMPOSE build webshoppingapigw mobileshoppingapigw
+
+  echo "=== [3/4] Building remaining SUT images ==="
+  $COMPOSE build
+else
+  echo "=== [2/4] Skipping build (--no-build flag set) ==="
+  echo "=== [3/4] Building Envoy gateway images (always rebuilt for correct TAG) ==="
+  $COMPOSE build webshoppingapigw mobileshoppingapigw
+fi
+
+echo "=== [4/4] Starting SUT containers ==="
+$COMPOSE up -d
+
+echo ""
+echo "Waiting for WebMVC to be ready (up to 200 seconds)..."
+COUNTER=0
+WAIT_LIMIT=40
+
+until curl -sf "http://localhost:5100" 2>/dev/null | grep -q "esh-catalog-item"; do
+  printf "  attempt %d/%d\r" "$((COUNTER + 1))" "$WAIT_LIMIT"
+  sleep 5
+  COUNTER=$((COUNTER + 1))
+  if [ "$COUNTER" -ge "$WAIT_LIMIT" ]; then
+    echo ""
+    echo "ERROR: SUT did not become ready in time. Last container logs:"
+    $COMPOSE logs --tail=30
+    exit 1
+  fi
+done
+
+echo ""
+echo "============================================"
+echo " SUT is ready!"
+echo "============================================"
+echo "  WebMVC      http://localhost:5100"
+echo "  WebSPA      http://localhost:5104"
+echo "  WebStatus   http://localhost:5107"
+echo "  Identity    http://localhost:5105"
+echo "  Seq (logs)  http://localhost:5340"
+echo "  RabbitMQ    http://localhost:15672  (guest/guest)"
+echo "  SQL Server  localhost:5433         (sa/Pass@word)"
+echo ""
+echo "To tear down:"
+echo "  docker compose -f sut/src/docker-compose.yml \\"
+echo "    -f sut/src/docker-compose.local-override.yml \\"
+echo "    --env-file .retorch/envfiles/local.env \\"
+echo "    -p local down --volumes"

--- a/sut/src/Web/WebMVC/Extensions/Extensions.cs
+++ b/sut/src/Web/WebMVC/Extensions/Extensions.cs
@@ -54,6 +54,12 @@ internal static class Extensions
         var callBackUrl = configuration.GetRequiredValue("CallBackUrl");
         var sessionCookieLifetime = configuration.GetValue("SessionCookieLifetimeMinutes", 60);
 
+        // ExternalIdentityUrl rewrites the browser-facing OAuth redirect to a URL the browser
+        // can actually reach. Needed for local Docker Desktop deployments where port mappings
+        // only bind to 127.0.0.1 and IdentityUrl uses Docker-internal DNS (e.g. identity_api_local).
+        // When not set it defaults to IdentityUrl so CI parallel deployments are unaffected.
+        var externalIdentityUrl = configuration.GetValue<string>("ExternalIdentityUrl") ?? identityUrl;
+
         // Add Authentication services
         services.AddAuthentication(options =>
         {
@@ -95,6 +101,25 @@ internal static class Extensions
             // JwtSecurityTokenHandler.DefaultInboundClaimTypeMap. Without this, "sub" gets
             // remapped to ClaimTypes.NameIdentifier and IdentityParser.Parse() returns Id = ""
             options.MapInboundClaims = false;
+
+            // When ExternalIdentityUrl differs from IdentityUrl, replace the internal Docker
+            // DNS hostname in the browser-facing redirect with the localhost-accessible URL.
+            // Token exchange and userinfo calls are server-side and keep using IdentityUrl.
+            if (!string.Equals(identityUrl, externalIdentityUrl, StringComparison.OrdinalIgnoreCase))
+            {
+                options.Events.OnRedirectToIdentityProvider = ctx =>
+                {
+                    ctx.ProtocolMessage.IssuerAddress = ctx.ProtocolMessage.IssuerAddress
+                        .Replace(identityUrl, externalIdentityUrl, StringComparison.OrdinalIgnoreCase);
+                    return Task.CompletedTask;
+                };
+                options.Events.OnRedirectToIdentityProviderForSignOut = ctx =>
+                {
+                    ctx.ProtocolMessage.IssuerAddress = ctx.ProtocolMessage.IssuerAddress
+                        .Replace(identityUrl, externalIdentityUrl, StringComparison.OrdinalIgnoreCase);
+                    return Task.CompletedTask;
+                };
+            }
         });
     }
 

--- a/sut/src/docker-compose.local-override.yml
+++ b/sut/src/docker-compose.local-override.yml
@@ -1,0 +1,124 @@
+# Local deployment override for docker-compose.yml.
+#
+# Differences from CI deployment:
+#  - jenkins_network is created locally instead of expected as external
+#  - All services expose ports so the host browser and local tests can reach them
+#  - webmvc: IdentityUrl stays as Docker DNS (identity_api_local) for server-side OIDC calls;
+#    ExternalIdentityUrl=http://localhost:5105 rewrites the browser-facing OAuth redirect via
+#    the OnRedirectToIdentityProvider event added to WebMVC/Extensions/Extensions.cs.
+#    Docker Desktop on Windows only proxies mapped ports to 127.0.0.1 (not host.docker.internal
+#    or the LAN IP), so localhost:5105 is the only address the browser can reliably reach.
+#  - webspa: IdentityUrl set to localhost:5105 directly (Angular OIDC runs entirely in the
+#    browser, no server-side discovery calls from the container).
+#  - identity-api callback URIs updated to localhost ports for browser redirects
+#  - CallBackUrl corrected from the appsettings default (port 5331) to port 5100
+#
+# CI parallel deployments: ExternalIdentityUrl is NOT set in CI env files, so it defaults to
+# IdentityUrl and the event handler is never registered. No impact on CI behaviour.
+#
+# Usage (run from project root):
+#   Linux:   ./redeploy-local.sh
+#   Windows: .\redeploy-local.ps1
+
+services:
+  seq:
+    ports:
+      - "5340:80"
+
+  sqldata:
+    ports:
+      - "5433:1433"
+
+  rabbitmq:
+    ports:
+      - "15672:15672"
+      - "5672:5672"
+
+  identity-api:
+    ports:
+      - "5105:80"
+    environment:
+      - MvcClient=http://localhost:5100
+      - SpaClient=http://localhost:5104
+      - WebhooksWebClient=http://localhost:5114
+      - WebhooksApiClient=http://localhost:5113
+
+  basket-api:
+    ports:
+      - "5103:80"
+
+  catalog-api:
+    ports:
+      - "5101:80"
+
+  ordering-api:
+    ports:
+      - "5102:80"
+
+  ordering-backgroundtasks:
+    ports:
+      - "5111:80"
+
+  payment-api:
+    ports:
+      - "5108:80"
+
+  webhooks-api:
+    ports:
+      - "5113:80"
+
+  mobileshoppingagg:
+    ports:
+      - "5120:80"
+
+  webshoppingagg:
+    ports:
+      - "5121:80"
+
+  ordering-signalrhub:
+    ports:
+      - "5112:80"
+
+  webstatus:
+    ports:
+      - "5107:80"
+
+  webspa:
+    ports:
+      - "5104:80"
+    environment:
+      # Angular OIDC runs entirely in the browser, so localhost:PORT is correct here.
+      - IdentityUrl=http://localhost:5105
+      - PurchaseUrl=http://localhost:5121
+      - SignalrHubUrl=http://localhost:5121
+
+  webmvc:
+    ports:
+      - "5100:80"
+    environment:
+      # IdentityUrl stays as Docker DNS so the container can fetch the discovery document
+      # and call token/userinfo endpoints server-side. ExternalIdentityUrl rewrites the
+      # browser-facing authorization redirect (see WebMVC/Extensions/Extensions.cs).
+      - ExternalIdentityUrl=http://localhost:5105
+      # SignalrHubUrl is injected into Razor pages for browser-side JS; localhost works.
+      - SignalrHubUrl=http://localhost:5121
+      # CallBackUrl default in appsettings.json points to port 5331; fix to actual local port.
+      - CallBackUrl=http://localhost:5100/signout-callback-oidc
+
+  webhooks-client:
+    ports:
+      - "5114:80"
+
+  webshoppingapigw:
+    ports:
+      - "5202:80"
+
+  mobileshoppingapigw:
+    ports:
+      - "5200:80"
+
+networks:
+  jenkins_network:
+    external: false
+    driver: bridge
+    name: eshop_local_network


### PR DESCRIPTION
The current version of the SUT does not allow local deployment and access through a host-bound port. This PR closes #287, addressing this problem through:

- Solved problems with identity service,  enabling the requests between services using the host IP address.
- Added Docker compose override file and the local.env file to deploy on your host, binding the necessary ports
- Added deployment scripts for both Linux and Windows.
- Adding the necessary explanations in the README.md to deploy the system locally (and then execute the test suite)

Please, test that you're able to deploy the SUT locally, access it through  the URL: http://localhost:5100, and authentificate using user: Bob passwd: Pass123$