### PR TITLE
Combined dependency updates (2026-05-29)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
         <selenium-java.version>4.44.0</selenium-java.version>
 
-		<selema.version>4.0.2</selema.version>
+		<selema.version>4.1.0</selema.version>
 
 		<retorch-tool.version>1.2.0</retorch-tool.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
         <log4j-slf4j2-impl.version>2.26.0</log4j-slf4j2-impl.version>
 
-        <junit-jupiter-api.version>6.0.3</junit-jupiter-api.version>
+        <junit-jupiter-api.version>6.1.0</junit-jupiter-api.version>
 
         <selenium-java.version>4.44.0</selenium-java.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!--Separate all dependencies by a blank line to avoid problems creating combined dependencies in dependabot.-->
 
-        <surefire.version>3.5.5</surefire.version>
+        <surefire.version>3.5.6</surefire.version>
 
         <slf4j-api.version>2.0.18</slf4j-api.version>
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump surefire.version from 3.5.5 to 3.5.6](https://github.com/giis-uniovi/retorch-st-eShopContainers/pull/300)
- [Bump junit-jupiter-api.version from 6.0.3 to 6.1.0](https://github.com/giis-uniovi/retorch-st-eShopContainers/pull/299)
- [Bump io.github.javiertuya:selema from 4.0.2 to 4.1.0](https://github.com/giis-uniovi/retorch-st-eShopContainers/pull/298)