### PR TITLE
Adding the neccesary rules to the dependabot.yml file to maintain updated the SUT

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,50 @@ updates:
       - "ClaudiodelaRiva"
     rebase-strategy: "disabled"
     open-pull-requests-limit: 20
+# SUT UPDATES
+  - package-ecosystem: "nuget"
+    directories:
+      - "/sut/**/*"
+    schedule:
+      interval: weekly
+      day: "friday"
+      time: "00:40"
+      timezone: "Europe/Madrid"
+    assignees:
+      - "ClaudiodelaRiva"
+    rebase-strategy: "disabled"
+    open-pull-requests-limit: 30
+    ignore:
+      # Block ALL .NET major-version bumps (runtime, ASP.NET Core, EF Core, etc.)
+      - dependency-name: "Microsoft.AspNetCore.*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Microsoft.EntityFrameworkCore.*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Microsoft.Extensions.*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Microsoft.NET.*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "System.*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "npm"
+    directory: "/sut/src/Web/WebSPA/Client"
+    schedule:
+      interval: weekly
+      day: "friday"
+      time: "00:40"
+      timezone: "Europe/Madrid"
+    assignees:
+      - "ClaudiodelaRiva"
+    rebase-strategy: "disabled"
+    ignore:
+      # Angular 21 LTS fixed in order to avoid accidental updates to the major version
+      - dependency-name: "@angular/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@angular-devkit/*"
+        update-types: ["version-update:semver-major"]
+      # @angular-devkit/build-angular 21.2.x requires typescript >=5.9 <6.0;
+      # only allow patch bumps within that supported range
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    open-pull-requests-limit: 20


### PR DESCRIPTION
This PR closes #316  by adding the necessary rules to our dependabot.yml file to make the continuous update of the NuGet and npm ecosystems (as requested at https://github.com/giis-uniovi/retorch/issues/167#issuecomment-4682838621) . Some minor remarks:

- Angular is always maintained to the 21 LTS version to avoid breaking changes in the SUT. This would be done manually yearly until the next LTS version.
- NET core is maintained up to version 10, which provides updates until November 2028. We intend to update this version to the last LTS one in the 28' Q2

This PR would be asked for review at the moment that the last updates and security fixes (#317 & #319 ) will be merged.