### PR TITLE
Change mechanism in CancelOrder for both frontends to solve flakiness

### DIFF
--- a/src/test/java/giis/eshopcontainers/e2e/functional/utils/Orders.java
+++ b/src/test/java/giis/eshopcontainers/e2e/functional/utils/Orders.java
@@ -125,12 +125,15 @@ public class Orders extends Shopping {
     /**
      * Navigates to the orders menu and press the Cancellation button of the last order. Checks that the order state
      * evolves as expected.
+     * Waits for the orders list to be non-empty before accessing it to guard against transient empty-list responses.
      *
      * @param driver {@code WebDriver} on which the operations are performed.
      * @param waiter {@code Waiter} to perform the necessary async waits.
      */
     public void cancelLastOrder(WebDriver driver, Waiter waiter) throws ElementNotFoundException {
         navUtils.toOrdersPage(driver, waiter);
+        waiter.waitUntil(ExpectedConditions.numberOfElementsToBeMoreThan(By.className("esh-orders-items"), 0),
+                "Orders list did not appear after navigation to orders page");
         List<WebElement> listOrders = driver.findElements(By.className("esh-orders-items"));
         WebElement lastOrder = listOrders.get(listOrders.size() - 1);
         WebElement cancelButton = lastOrder.findElement(By.linkText("Cancel"));

--- a/src/test/java/giis/eshopcontainers/e2e/functional/utils/OrdersWebSPA.java
+++ b/src/test/java/giis/eshopcontainers/e2e/functional/utils/OrdersWebSPA.java
@@ -130,6 +130,8 @@ public class OrdersWebSPA extends Orders {
 
     /**
      * Cancels the last order in the WebSPA frontend (SPA version).
+     * Waits for the orders list to be non-empty before accessing it: the SPA fetches
+     * orders asynchronously so the list can be transiently empty after navigation.
      *
      * @param driver {@code WebDriver} on which the operations are performed.
      * @param waiter {@code Waiter} to perform the necessary async waits.
@@ -137,6 +139,8 @@ public class OrdersWebSPA extends Orders {
     @Override
     public void cancelLastOrder(WebDriver driver, Waiter waiter) throws ElementNotFoundException {
         navUtils.toOrdersPage(driver, waiter);
+        waiter.waitUntil(ExpectedConditions.numberOfElementsToBeMoreThan(By.className("esh-orders-item"), 0),
+                "Orders list did not appear after navigation to orders page");
         List<WebElement> listOrders = driver.findElements(By.className("esh-orders-item"));
         WebElement lastOrder = listOrders.get(listOrders.size() - 1);
         WebElement cancelLink = lastOrder.findElement(By.linkText("Cancel"));


### PR DESCRIPTION
This PR closes #398 by integrating a new mechanism for the CancelOrders in both frontend methods (WebSPA and WebMVC). 
The new mechanism, instead of retrieving the orders directly, waits until the number matches the expected value, ensuring the retrieved list of orders is never empty.
