### PR TITLE
Excluding migration DB files to solve Sonar Quality Gate problems

### DIFF
--- a/sonar.properties
+++ b/sonar.properties
@@ -5,4 +5,4 @@ sonar.host.url=https://sonarcloud.io
 # environment-specific). Paths below are relative to that base directory.
 sonar.typescript.tsconfigPaths=src/Web/WebSPA/Client/tsconfig.json,src/Web/WebSPA/Client/tsconfig.app.json
 
-sonar.exclusions=**/node_modules/**,**/bin/**,**/obj/**,**/Migrations/**,**/wwwroot/lib/**,**/*.min.css,**/*.min.js,**/.angular/**,**/*.png,**/*.jpg,**/*.ico,**/*.zip,**/*.pfx,**/*.woff,**/*.woff2,**/*.ttf,**/*.eot
+sonar.exclusions=**/node_modules/**,**/bin/**,**/obj/**,**/*Migrations/**,**/wwwroot/lib/**,**/*.min.css,**/*.min.js,**/.angular/**,**/*.png,**/*.jpg,**/*.ico,**/*.zip,**/*.pfx,**/*.woff,**/*.woff2,**/*.ttf,**/*.eot


### PR DESCRIPTION
This PR closes #322 , as noted by @javiertuya : 
> Note that overall code https://sonarcloud.io/summary/overall?id=my%3Aretorch-st-eShopContainers&branch=main displays a large number of issues, possibly due to temporary files created during deployment. If these files aren’t excluded, the next scan could flag new code issues in them.

The quality gate was failing because the migration files (under **/migration/**) were analyzed and taken into account during the quality gate computation. This PR includes the necessary changes to the sonar.properties file to exclude these files and prevent this step from failing for this reason in the future.