### PR TITLE
Combined dependency updates (2026-07-27)

### DIFF
--- a/sut/src/Directory.Packages.props
+++ b/sut/src/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="Grpc.Core" Version="2.46.6" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.51.0" />
     <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.51.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.82.0" PrivateAssets="All" />
+    <PackageVersion Include="Grpc.Tools" Version="2.83.0" PrivateAssets="All" />
     <PackageVersion Include="MediatR" Version="14.1.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.23.0" />

--- a/sut/src/Directory.Packages.props
+++ b/sut/src/Directory.Packages.props
@@ -22,8 +22,8 @@
     <PackageVersion Include="Duende.IdentityServer" Version="8.0.2" />
     <PackageVersion Include="Duende.IdentityServer.AspNetIdentity" Version="8.0.2" />
     <PackageVersion Include="Duende.IdentityServer.EntityFramework" Version="8.0.2" />
-    <PackageVersion Include="Duende.IdentityServer.EntityFramework.Storage" Version="8.0.2" />
-    <PackageVersion Include="Duende.IdentityServer.Storage" Version="8.0.2" />
+    <PackageVersion Include="Duende.IdentityServer.EntityFramework.Storage" Version="8.0.3" />
+    <PackageVersion Include="Duende.IdentityServer.Storage" Version="8.0.3" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageVersion Include="Google.Protobuf" Version="3.35.1" />
     <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.51.0" />

--- a/sut/src/Directory.Packages.props
+++ b/sut/src/Directory.Packages.props
@@ -19,11 +19,11 @@
     <PackageVersion Include="BuildBundlerMinifier" Version="3.2.449" />
     <PackageVersion Include="Dapper" Version="2.1.79" />
     <PackageVersion Include="Duende.IdentityModel" Version="8.1.0" />
-    <PackageVersion Include="Duende.IdentityServer" Version="8.0.2" />
-    <PackageVersion Include="Duende.IdentityServer.AspNetIdentity" Version="8.0.2" />
+    <PackageVersion Include="Duende.IdentityServer" Version="8.0.3" />
+    <PackageVersion Include="Duende.IdentityServer.AspNetIdentity" Version="8.0.3" />
     <PackageVersion Include="Duende.IdentityServer.EntityFramework" Version="8.0.2" />
     <PackageVersion Include="Duende.IdentityServer.EntityFramework.Storage" Version="8.0.2" />
-    <PackageVersion Include="Duende.IdentityServer.Storage" Version="8.0.2" />
+    <PackageVersion Include="Duende.IdentityServer.Storage" Version="8.0.3" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageVersion Include="Google.Protobuf" Version="3.35.1" />
     <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.51.0" />

--- a/sut/src/Web/WebSPA/Client/package-lock.json
+++ b/sut/src/Web/WebSPA/Client/package-lock.json
@@ -271,6 +271,25 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@angular-devkit/architect": {
+      "version": "0.2102.19",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2102.19.tgz",
+      "integrity": "sha512-cj4tzUMiloLTg5rNf17E8MsvIxCWYoBiBsaj7ns6dgXqT9XCeG+J0TA2t1M+N9uuqfeLd22U/rYoCkADmcircQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-devkit/core": "21.2.19",
+        "rxjs": "7.8.2"
+      },
+      "bin": {
+        "architect": "bin/cli.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
     "node_modules/@angular-devkit/build-angular": {
       "version": "21.2.19",
       "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-21.2.19.tgz",
@@ -424,29 +443,10 @@
         "webpack-dev-server": "^5.0.2"
       }
     },
-    "node_modules/@angular-devkit/build-webpack/node_modules/@angular-devkit/architect": {
-      "version": "0.2102.17",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2102.17.tgz",
-      "integrity": "sha512-+lkmpEfKXuPZaGZRCCT/B2JGSnafudEVMLeolAW0G7de28bwJIwTE5nmr/rcKTy4NnEDX/8B53tWTXGENuQvmg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@angular-devkit/core": "21.2.17",
-        "rxjs": "7.8.2"
-      },
-      "bin": {
-        "architect": "bin/cli.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@angular-devkit/build-webpack/node_modules/@angular-devkit/core": {
-      "version": "21.2.17",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.17.tgz",
-      "integrity": "sha512-JbGWwFX1Nv4Np0S9b4HP2SUKhR2bz6l/S8zBXnam95+RXzDaqXJDmQHOHZGS+4La06SjlcXwFyrgSI0rm50A1A==",
+    "node_modules/@angular-devkit/core": {
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.19.tgz",
+      "integrity": "sha512-dtpJMQBz5nhkcIogPmXP/aT2Ak8m/wLRPOSTI/g4vSJSuGiI53PgtWq4/wfQga6E6wdM2XWsblAE89d8w5heQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -472,13 +472,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "21.2.18",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.18.tgz",
-      "integrity": "sha512-PakHs+Eefx06KORDFyH4wmkIZ/wm4mI4DqhXe4XFuWJOazMQoYJxPmMeby47BD0HhvJN7BskN61CPS8HCAvICg==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.19.tgz",
+      "integrity": "sha512-AG3Fzh9wJCmKBfxUQOUWaEHMj5Gq2O+Msf1z52aDSxbVhs5/iSQcXGPv/DLdAXu7d4xmQhLouNe9Glaq2omDyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "21.2.18",
+        "@angular-devkit/core": "21.2.19",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.21",
         "ora": "9.3.0",
@@ -488,34 +488,6 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@angular-devkit/schematics/node_modules/@angular-devkit/core": {
-      "version": "21.2.18",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.18.tgz",
-      "integrity": "sha512-783AuDmzAjFkOBHey7cx1mXd8CTiMg9LvG+BCxEp8i4EB7cOGYrq3lBzkwhKJq6yYpz7dNgM1QgeLk+NcrFBSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "8.18.0",
-        "ajv-formats": "3.0.1",
-        "jsonc-parser": "3.3.1",
-        "picomatch": "4.0.4",
-        "rxjs": "7.8.2",
-        "source-map": "0.7.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      },
-      "peerDependencies": {
-        "chokidar": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "chokidar": {
-          "optional": true
-        }
       }
     },
     "node_modules/@angular/animations": {
@@ -677,71 +649,10 @@
         "tslib": "^2.3.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@angular/cli/node_modules/@angular-devkit/core": {
-      "version": "21.2.17",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.17.tgz",
-      "integrity": "sha512-JbGWwFX1Nv4Np0S9b4HP2SUKhR2bz6l/S8zBXnam95+RXzDaqXJDmQHOHZGS+4La06SjlcXwFyrgSI0rm50A1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "8.18.0",
-        "ajv-formats": "3.0.1",
-        "jsonc-parser": "3.3.1",
-        "picomatch": "4.0.4",
-        "rxjs": "7.8.2",
-        "source-map": "0.7.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      },
-      "peerDependencies": {
-        "chokidar": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "chokidar": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@angular/cli/node_modules/@angular-devkit/schematics": {
-      "version": "21.2.17",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.17.tgz",
-      "integrity": "sha512-IMsbo/OBG0mdCRxezbq/CLo6JxUJBOAHZfbUDzxbSRwJm8FT5AbXO7rW+Z3haoqcb+WrC5Pr+DQ6WolX2x2brQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@angular-devkit/core": "21.2.17",
-        "jsonc-parser": "3.3.1",
-        "magic-string": "0.30.21",
-        "ora": "9.3.0",
-        "rxjs": "7.8.2"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@angular/common": {
-      "version": "21.2.17",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.17.tgz",
-      "integrity": "sha512-hqAQxRfi5ldFE42suAXRcY+JCANrUh7fuSQ/DtZ7L896id5BT/exuv6dWNBC1PyAfQmRbpD5Pt6/pd+tNLyhDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "21.2.17",
+        "@angular/core": "21.2.18",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -5977,53 +5888,6 @@
         "@angular-devkit/core": "21.2.19",
         "@angular-devkit/schematics": "21.2.19",
         "jsonc-parser": "3.3.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@schematics/angular/node_modules/@angular-devkit/core": {
-      "version": "21.2.17",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.17.tgz",
-      "integrity": "sha512-JbGWwFX1Nv4Np0S9b4HP2SUKhR2bz6l/S8zBXnam95+RXzDaqXJDmQHOHZGS+4La06SjlcXwFyrgSI0rm50A1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "8.18.0",
-        "ajv-formats": "3.0.1",
-        "jsonc-parser": "3.3.1",
-        "picomatch": "4.0.4",
-        "rxjs": "7.8.2",
-        "source-map": "0.7.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      },
-      "peerDependencies": {
-        "chokidar": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "chokidar": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@schematics/angular/node_modules/@angular-devkit/schematics": {
-      "version": "21.2.17",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.17.tgz",
-      "integrity": "sha512-IMsbo/OBG0mdCRxezbq/CLo6JxUJBOAHZfbUDzxbSRwJm8FT5AbXO7rW+Z3haoqcb+WrC5Pr+DQ6WolX2x2brQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@angular-devkit/core": "21.2.17",
-        "jsonc-parser": "3.3.1",
-        "magic-string": "0.30.21",
-        "ora": "9.3.0",
-        "rxjs": "7.8.2"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",

--- a/sut/src/Web/WebSPA/Client/package-lock.json
+++ b/sut/src/Web/WebSPA/Client/package-lock.json
@@ -271,6 +271,25 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@angular-devkit/architect": {
+      "version": "0.2102.19",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2102.19.tgz",
+      "integrity": "sha512-cj4tzUMiloLTg5rNf17E8MsvIxCWYoBiBsaj7ns6dgXqT9XCeG+J0TA2t1M+N9uuqfeLd22U/rYoCkADmcircQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-devkit/core": "21.2.19",
+        "rxjs": "7.8.2"
+      },
+      "bin": {
+        "architect": "bin/cli.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
     "node_modules/@angular-devkit/build-angular": {
       "version": "21.2.19",
       "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-21.2.19.tgz",
@@ -424,29 +443,10 @@
         "webpack-dev-server": "^5.0.2"
       }
     },
-    "node_modules/@angular-devkit/build-webpack/node_modules/@angular-devkit/architect": {
-      "version": "0.2102.17",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2102.17.tgz",
-      "integrity": "sha512-+lkmpEfKXuPZaGZRCCT/B2JGSnafudEVMLeolAW0G7de28bwJIwTE5nmr/rcKTy4NnEDX/8B53tWTXGENuQvmg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@angular-devkit/core": "21.2.17",
-        "rxjs": "7.8.2"
-      },
-      "bin": {
-        "architect": "bin/cli.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@angular-devkit/build-webpack/node_modules/@angular-devkit/core": {
-      "version": "21.2.17",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.17.tgz",
-      "integrity": "sha512-JbGWwFX1Nv4Np0S9b4HP2SUKhR2bz6l/S8zBXnam95+RXzDaqXJDmQHOHZGS+4La06SjlcXwFyrgSI0rm50A1A==",
+    "node_modules/@angular-devkit/core": {
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.19.tgz",
+      "integrity": "sha512-dtpJMQBz5nhkcIogPmXP/aT2Ak8m/wLRPOSTI/g4vSJSuGiI53PgtWq4/wfQga6E6wdM2XWsblAE89d8w5heQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -472,13 +472,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "21.2.18",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.18.tgz",
-      "integrity": "sha512-PakHs+Eefx06KORDFyH4wmkIZ/wm4mI4DqhXe4XFuWJOazMQoYJxPmMeby47BD0HhvJN7BskN61CPS8HCAvICg==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.19.tgz",
+      "integrity": "sha512-AG3Fzh9wJCmKBfxUQOUWaEHMj5Gq2O+Msf1z52aDSxbVhs5/iSQcXGPv/DLdAXu7d4xmQhLouNe9Glaq2omDyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "21.2.18",
+        "@angular-devkit/core": "21.2.19",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.21",
         "ora": "9.3.0",
@@ -488,34 +488,6 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@angular-devkit/schematics/node_modules/@angular-devkit/core": {
-      "version": "21.2.18",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.18.tgz",
-      "integrity": "sha512-783AuDmzAjFkOBHey7cx1mXd8CTiMg9LvG+BCxEp8i4EB7cOGYrq3lBzkwhKJq6yYpz7dNgM1QgeLk+NcrFBSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "8.18.0",
-        "ajv-formats": "3.0.1",
-        "jsonc-parser": "3.3.1",
-        "picomatch": "4.0.4",
-        "rxjs": "7.8.2",
-        "source-map": "0.7.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      },
-      "peerDependencies": {
-        "chokidar": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "chokidar": {
-          "optional": true
-        }
       }
     },
     "node_modules/@angular/animations": {
@@ -677,71 +649,10 @@
         "tslib": "^2.3.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@angular/cli/node_modules/@angular-devkit/core": {
-      "version": "21.2.17",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.17.tgz",
-      "integrity": "sha512-JbGWwFX1Nv4Np0S9b4HP2SUKhR2bz6l/S8zBXnam95+RXzDaqXJDmQHOHZGS+4La06SjlcXwFyrgSI0rm50A1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "8.18.0",
-        "ajv-formats": "3.0.1",
-        "jsonc-parser": "3.3.1",
-        "picomatch": "4.0.4",
-        "rxjs": "7.8.2",
-        "source-map": "0.7.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      },
-      "peerDependencies": {
-        "chokidar": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "chokidar": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@angular/cli/node_modules/@angular-devkit/schematics": {
-      "version": "21.2.17",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.17.tgz",
-      "integrity": "sha512-IMsbo/OBG0mdCRxezbq/CLo6JxUJBOAHZfbUDzxbSRwJm8FT5AbXO7rW+Z3haoqcb+WrC5Pr+DQ6WolX2x2brQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@angular-devkit/core": "21.2.17",
-        "jsonc-parser": "3.3.1",
-        "magic-string": "0.30.21",
-        "ora": "9.3.0",
-        "rxjs": "7.8.2"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@angular/common": {
-      "version": "21.2.17",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.17.tgz",
-      "integrity": "sha512-hqAQxRfi5ldFE42suAXRcY+JCANrUh7fuSQ/DtZ7L896id5BT/exuv6dWNBC1PyAfQmRbpD5Pt6/pd+tNLyhDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "21.2.17",
+        "@angular/core": "21.2.18",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -5984,53 +5895,6 @@
         "yarn": ">= 1.13.0"
       }
     },
-    "node_modules/@schematics/angular/node_modules/@angular-devkit/core": {
-      "version": "21.2.17",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.17.tgz",
-      "integrity": "sha512-JbGWwFX1Nv4Np0S9b4HP2SUKhR2bz6l/S8zBXnam95+RXzDaqXJDmQHOHZGS+4La06SjlcXwFyrgSI0rm50A1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "8.18.0",
-        "ajv-formats": "3.0.1",
-        "jsonc-parser": "3.3.1",
-        "picomatch": "4.0.4",
-        "rxjs": "7.8.2",
-        "source-map": "0.7.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      },
-      "peerDependencies": {
-        "chokidar": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "chokidar": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@schematics/angular/node_modules/@angular-devkit/schematics": {
-      "version": "21.2.17",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.17.tgz",
-      "integrity": "sha512-IMsbo/OBG0mdCRxezbq/CLo6JxUJBOAHZfbUDzxbSRwJm8FT5AbXO7rW+Z3haoqcb+WrC5Pr+DQ6WolX2x2brQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@angular-devkit/core": "21.2.17",
-        "jsonc-parser": "3.3.1",
-        "magic-string": "0.30.21",
-        "ora": "9.3.0",
-        "rxjs": "7.8.2"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      }
-    },
     "node_modules/@sigstore/bundle": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-4.0.0.tgz",
@@ -8666,9 +8530,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump the angular group across 1 directory with 2 updates](https://github.com/giis-uniovi/retorch-st-eShopContainers/pull/441)
- [Bump fast-uri from 3.1.3 to 3.1.4 in /sut/src/Web/WebSPA/Client](https://github.com/giis-uniovi/retorch-st-eShopContainers/pull/458)
- [Bump Grpc.Tools from 2.82.0 to 2.83.0](https://github.com/giis-uniovi/retorch-st-eShopContainers/pull/456)
- [Bump Duende.IdentityServer.EntityFramework.Storage and Duende.IdentityServer.Storage](https://github.com/giis-uniovi/retorch-st-eShopContainers/pull/445)
- [Bump Duende.IdentityServer and 2 others](https://github.com/giis-uniovi/retorch-st-eShopContainers/pull/443)